### PR TITLE
chore: fix completion plugin typo

### DIFF
--- a/nvim/lua/plugins/completion.lua
+++ b/nvim/lua/plugins/completion.lua
@@ -21,7 +21,7 @@ return {
     end,
   },
   {
-    "nvim-cmp",
+    "hrsh7th/nvim-cmp",
     dependencies = {
       "hrsh7th/cmp-nvim-lsp",
       "hrsh7th/cmp-buffer",


### PR DESCRIPTION
Fix nvm-cmp pluging install